### PR TITLE
remove mutex copying

### DIFF
--- a/taglog/taglog_race_test.go
+++ b/taglog/taglog_race_test.go
@@ -1,0 +1,43 @@
+// +build race
+
+package taglog
+
+import (
+	"bytes"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestRace(t *testing.T) {
+	n := 100
+	buf := &bytes.Buffer{}
+	buf.Grow(1 << 20)
+	var wg sync.WaitGroup
+
+	lg := New(buf, "", 0)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < n; i++ {
+			lg.Println("line")
+		}
+	}()
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		l := lg.Copy()
+		l.SetPrefix(fmt.Sprintf("Copy%d ", i+1))
+		go func(l *Logger) {
+			defer wg.Done()
+			for i := 0; i < n; i++ {
+				l.Println("line")
+			}
+		}(l)
+	}
+
+	wg.Wait()
+
+	t.Logf("%db written", len(buf.Bytes()))
+}

--- a/taglog/taglog_test.go
+++ b/taglog/taglog_test.go
@@ -1,0 +1,18 @@
+package taglog
+
+import "os"
+
+func ExampleCopy() {
+	orig := New(os.Stdout, "A ", 0)
+	orig.Println("a")
+	copy := orig.Copy()
+	orig.Println("b")
+	copy.SetPrefix("B ")
+	orig.Println("c")
+	copy.Println("c")
+	// Output:
+	// A a
+	// A b
+	// A c
+	// B c
+}


### PR DESCRIPTION
Copying a Logger's embedded mutex is not allowed according to the
documentation, and trips the race detector.

This rewrites the mutex to only protect the io.Writer, and in such a way
that it can be copied. The result no longer trips the race detector, but
may have surprising semantics.